### PR TITLE
Minor change to conform Python3 float division

### DIFF
--- a/filters.py
+++ b/filters.py
@@ -89,7 +89,7 @@ def prune(G, field='significance', percent=None, num_remove=None):
     if percent:
         deathrow = []
         n = len(G.es)
-        threshold_index = n - n * percent / 100
+        threshold_index = int(n - n * percent / 100)
         threshold_value = sorted(G.es[field])[threshold_index]
 
         for e in G.es:


### PR DESCRIPTION
_threshold_index_ is used as index hence must be an integer. By default, Python 3.x does a true division rather than floor division. With this simple change, it behaves like floor division.